### PR TITLE
rename string headers to avoid conflict with glibc strings.h

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -25,7 +25,7 @@ HEADERS += openprojectdialog.h \
     settings.h \
     session.h \
     queryview.h \
-    strings.h \
+    appstrings.h \
     locationhistory.h \
     projectmanager.h \
     projectfilesdialog.h \

--- a/app/appstrings.h
+++ b/app/appstrings.h
@@ -18,8 +18,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  ***************************************************************************/
 
-#ifndef __APP_STRINGS_H__
-#define __APP_STRINGS_H__
+#ifndef __APP_APPSRINGS_H__
+#define __APP_APPSTRINGS_H__
 
 #include <QString>
 
@@ -117,4 +117,4 @@ public:
 
 } // namespace KScope
 
-#endif // __APP_STRINGS_H__
+#endif // __APP_APPSTRINGS_H__

--- a/app/querydialog.cpp
+++ b/app/querydialog.cpp
@@ -23,7 +23,7 @@
 #include <QMessageBox>
 #include <QDebug>
 #include "querydialog.h"
-#include "strings.h"
+#include "appstrings.h"
 
 namespace KScope
 {

--- a/app/queryresultdock.cpp
+++ b/app/queryresultdock.cpp
@@ -20,7 +20,7 @@
 
 #include "queryresultdock.h"
 #include "projectmanager.h"
-#include "strings.h"
+#include "appstrings.h"
 
 namespace KScope
 {

--- a/core/corestrings.h
+++ b/core/corestrings.h
@@ -18,8 +18,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  ***************************************************************************/
 
-#ifndef __CORE_STRINGS_H__
-#define __CORE_STRINGS_H__
+#ifndef __CORE_CORESTRINGS_H__
+#define __CORE_CORESTRINGS_H__
 
 #include "globals.h"
 
@@ -92,4 +92,4 @@ struct Strings : public QObject
 
 } // namespace KScope
 
-#endif // __CORE_STRINGS_H__
+#endif // __CORE_CORESTRINGS_H__

--- a/core/locationmodel.cpp
+++ b/core/locationmodel.cpp
@@ -19,7 +19,7 @@
  ***************************************************************************/
 
 #include "locationmodel.h"
-#include "strings.h"
+#include "corestrings.h"
 #include "images.h"
 #include <QDir>
 


### PR DESCRIPTION
With the latest versions of gcc and glibc, the code pulls in glibc's "strings.h" instead of the local copy, resulting in lots of errors and a failed build. Rather than try to manipulate include flags to work around this, the simple fix is to rename the files to avoid the namespace conflict.